### PR TITLE
Fix some python3 errors

### DIFF
--- a/python/pic_programmer.py
+++ b/python/pic_programmer.py
@@ -326,9 +326,9 @@ def main():
                             buf = ""
                             r = arduino.read()
                             while r.decode() != "X":
-                                buf += r
+                                buf += r.decode("utf-8")
                                 r = arduino.read()
-                            buf += r
+                            buf += r.decode("utf-8")
 
                             if verbose:
                                 print(buf)


### PR DESCRIPTION
Added .decode("utf-8") to byte concontenation in pic_programmer.py on… lines 329 and 331

Fixes ""TypeError: can only concatenate str (not "bytes") to str"" error on programming